### PR TITLE
Add `delete_tmpfiles` as config file option

### DIFF
--- a/docs/howto/config.rst
+++ b/docs/howto/config.rst
@@ -1,14 +1,5 @@
 .. _howto_config:
 
-Environment variables
-=====================
-
-PYSAML2_DELETE_TMPFILES
-^^^^^^^^^^^^^^^^^^^^^^^
-
-If set to "False" will keep temporary xml files in the system temporary storage.
-Default: "true"; delete temporary files.
-
 
 Configuration of pySAML2 entities
 =================================
@@ -44,6 +35,7 @@ The basic structure of the configuration file is therefore like this::
         "key_file" : "my.key",
         "cert_file" : "ca.pem",
         "xmlsec_binary" : "/usr/local/bin/xmlsec1",
+        "delete_tmpfiles": True,
         "metadata": {
             "local": ["edugain.xml"],
         },
@@ -325,6 +317,17 @@ This option defines where the binary is situated.
 Example::
 
     "xmlsec_binary": "/usr/local/bin/xmlsec1",
+
+delete_tmpfiles
+^^^^^^^^^^^^^^^
+
+In many cases temporary files will have to be created during the
+encryption/decryption/signing/validation process.
+This option defines whether these temporary files will be automatically deleted when
+they are no longer needed. Setting this to False, will keep these files until they are
+manually deleted or automatically deleted by the OS (i.e Linux rules for /tmp).
+Absence of this option, defaults to True.
+
 
 valid_for
 ^^^^^^^^^
@@ -826,6 +829,7 @@ We start with a simple but fairly complete Service provider configuration::
         "key_file" : "./mykey.pem",
         "cert_file" : "./mycert.pem",
         "xmlsec_binary" : "/usr/local/bin/xmlsec1",
+        "delete_tmpfiles": True,
         "attribute_map_dir": "./attributemaps",
         "metadata": {
             "local": ["idp.xml"]
@@ -874,6 +878,7 @@ A slightly more complex configuration::
         "key_file" : "./mykey.pem",
         "cert_file" : "./mycert.pem",
         "xmlsec_binary" : "/usr/local/bin/xmlsec1",
+        "delete_tmpfiles": True,
         "metadata" : {
             "local": ["example.xml"],
             "remote": [{

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -69,6 +69,7 @@ COMMON_ARGS = [
     "allow_unknown_attributes",
     "crypto_backend",
     "id_attr_name",
+    "delete_tmpfiles",
 ]
 
 SP_ARGS = [
@@ -243,7 +244,7 @@ class Config(object):
         self.attribute = []
         self.attribute_profile = []
         self.requested_attribute_name_format = NAME_FORMAT_URI
-        self.delete_tmpfiles = get_environ_delete_tmpfiles()
+        self.delete_tmpfiles = True
 
     def setattr(self, context, attr, val):
         if context == "":
@@ -358,6 +359,12 @@ class Config(object):
                 pass
             except TypeError:  # Something that can't be a string
                 setattr(self, arg, cnf[arg])
+
+        if not self.delete_tmpfiles:
+            logger.warning(
+                "delete_tmpfiles is set to False, "
+                "temporary files will not be deleted."
+            )
 
         if "service" in cnf:
             for typ in ["aa", "idp", "sp", "pdp", "aq"]:
@@ -596,17 +603,3 @@ def config_factory(_type, config):
 
     conf.context = _type
     return conf
-
-
-def get_environ_delete_tmpfiles():
-    default = "true"
-    value = os.environ.get("PYSAML2_DELETE_TMPFILES", default)
-    result = value.lower() == default
-
-    if not result:
-        logger.warning(
-            "PYSAML2_DELETE_TMPFILES set to False, "
-            "temporary xml files will not be deleted."
-        )
-
-    return result


### PR DESCRIPTION
- Removes PYSAML2_DELETE_TMPFILES environment attribute and moves it
to config attribute as `delete_tmpfiles`. Defaults to True
- Updates docs for new config attribute

### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?



